### PR TITLE
Release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Allow to store bytes content using Mock.
 
 ## [3.1.0] - 2019-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.2.0] - 2020-01-22
 ### Fixed
 - Allow to store bytes content using Mock.
 - Mock is now able to retrieve a file that was previously stored.
@@ -16,5 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/pyndows/compare/v3.1.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pyndows/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/Colin-b/pyndows/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/Colin-b/pyndows/releases/tag/v3.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow to store bytes content using Mock.
 - Mock is now able to retrieve a file that was previously stored.
 
+### Added
+- Mock stored files can now be retrieved with the help of a timeout via `try_get` method.
+
 ## [3.1.0] - 2019-12-03
 ### Added
 - Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Allow to store bytes content using Mock.
+- Mock is now able to retrieve a file that was previously stored.
 
 ## [3.1.0] - 2019-12-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Build status" src="https://api.travis-ci.org/Colin-b/pyndows.svg?branch=master"></a>
 <a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Number of tests" src="https://img.shields.io/badge/tests-23 passed-blue"></a>
+<a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Number of tests" src="https://img.shields.io/badge/tests-25 passed-blue"></a>
 <a href="https://pypi.org/project/pyndows/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pyndows"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <p align="center">
 <a href="https://pypi.org/project/pyndows/"><img alt="pypi version" src="https://img.shields.io/pypi/v/pyndows"></a>
-<a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Build status" src="https://api.travis-ci.org/Colin-b/pyndows.svg?branch=develop"></a>
+<a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Build status" src="https://api.travis-ci.org/Colin-b/pyndows.svg?branch=master"></a>
 <a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Number of tests" src="https://img.shields.io/badge/tests-20 passed-blue"></a>
+<a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Number of tests" src="https://img.shields.io/badge/tests-23 passed-blue"></a>
 <a href="https://pypi.org/project/pyndows/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pyndows"></a>
 </p>
 

--- a/pyndows/testing.py
+++ b/pyndows/testing.py
@@ -76,9 +76,13 @@ class SMBConnectionMock:
         )
 
     def retrieveFile(self, share_drive_path: str, file_path: str, file) -> (int, int):
-        retrieved_file_content = SMBConnectionMock.files_to_retrieve.pop(
-            (share_drive_path, file_path), None
-        )
+        file_id = (share_drive_path, file_path)
+        if file_id not in SMBConnectionMock.files_to_retrieve:
+            retrieved_file_content = SMBConnectionMock.stored_files.get(file_id)
+        else:
+            retrieved_file_content = SMBConnectionMock.files_to_retrieve.pop(
+                (share_drive_path, file_path), None
+            )
         if retrieved_file_content is not None:
             if os.path.isfile(retrieved_file_content):
                 with open(retrieved_file_content, mode="rb") as retrieved_file:

--- a/pyndows/testing.py
+++ b/pyndows/testing.py
@@ -84,7 +84,12 @@ class SMBConnectionMock:
                 with open(retrieved_file_content, mode="rb") as retrieved_file:
                     file.write(retrieved_file.read())
             else:
-                file.write(str.encode(retrieved_file_content))
+                try:
+                    # Try to store string in order to compare it easily
+                    file.write(str.encode(retrieved_file_content))
+                except TypeError:
+                    # Keep bytes when content is not str compatible (eg. Zip file)
+                    file.write(retrieved_file_content)
             return 0, 0
         raise OperationFailure("Mock for retrieveFile failure.", [])
 

--- a/pyndows/version.py
+++ b/pyndows/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "3.1.0"
+__version__ = "3.2.0"


### PR DESCRIPTION
### Fixed
- Allow to store bytes content using Mock.
- Mock is now able to retrieve a file that was previously stored.

### Added
- Mock stored files can now be retrieved with the help of a timeout via `try_get` method.
