### PR TITLE
Handle ? wildcard in mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Mock now replaces the ? wildcard defined in [MS-CIFS protocol](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/dc92d939-ec45-40c8-96e5-4c4091e4ab43) by a point.
 
 ## [3.3.0] - 2020-02-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.3.1] - 2020-02-06
 ### Fixed
-- Mock now replaces the ? wildcard defined in [MS-CIFS protocol](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/dc92d939-ec45-40c8-96e5-4c4091e4ab43) by a point.
+- Mock now replaces the `?` wildcard defined in [MS-CIFS protocol](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/dc92d939-ec45-40c8-96e5-4c4091e4ab43) by a `.`.
 
 ## [3.3.0] - 2020-02-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+
+## [3.3.1] - 2020-02-06
+### Fixed
 - Mock now replaces the ? wildcard defined in [MS-CIFS protocol](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/dc92d939-ec45-40c8-96e5-4c4091e4ab43) by a point.
 
 ## [3.3.0] - 2020-02-04
@@ -28,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/pyndows/compare/v3.3.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pyndows/compare/v3.3.1...HEAD
+[3.3.1]: https://github.com/Colin-b/pyndows/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/Colin-b/pyndows/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/Colin-b/pyndows/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/Colin-b/pyndows/releases/tag/v3.1.0

--- a/pyndows/_windows.py
+++ b/pyndows/_windows.py
@@ -150,6 +150,7 @@ def get_folder_content(
     Include sub folders by default. Set to False to list only files.
     :param pattern: Filter out files or sub folders based on this pattern (`*` character means all).
     Include everything but . and .. by default (*).
+    Respects the MS-CIFS protocol. https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/dc92d939-ec45-40c8-96e5-4c4091e4ab43
     :return: A List of SharedFile objects, empty if the given folder does not exist.
     """
     search = (

--- a/pyndows/testing.py
+++ b/pyndows/testing.py
@@ -132,6 +132,7 @@ class SMBConnectionMock:
         self, service_name: str, path: str, search: int = 0, pattern: str = "*",
     ) -> List[SharedFile]:
         pattern = pattern.replace("*", ".*")
+        pattern = pattern.replace("?", ".")
         service_name = service_name.replace("/", os.sep).replace("\\", os.sep)
         path = path.replace("/", os.sep).replace("\\", os.sep)
         path = path if not path or path.endswith(os.sep) else f"{path}{os.sep}"

--- a/pyndows/version.py
+++ b/pyndows/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "3.3.0"
+__version__ = "3.3.1"

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -379,6 +379,32 @@ def test_get_all_folder_contents_matching_a_pattern(samba_mock: SMBConnectionMoc
     ]
 
 
+def test_get_all_folder_contents_matching_a_pattern_with_question_mark_wildcard(
+    samba_mock: SMBConnectionMock,
+):
+    connection = pyndows.connect(
+        "TestComputer", "127.0.0.1", 80, "TestDomain", "TestUser", "TestPassword"
+    )
+
+    samba_mock.stored_files.update(
+        {
+            ("TestShare/", "test_12345_test"): "",
+            ("TestShare/", "test_123456_test"): "",
+            ("TestShare/", "test_123_test"): "",
+            ("TestShare/", "test_1234M_test"): "",
+        }
+    )
+
+    shared_folder_contents = pyndows.get_folder_content(
+        connection, "TestShare/", pattern="test_?????_test"
+    )
+
+    assert shared_folder_contents == [
+        SharedFileMock(filename="test_12345_test", isDirectory=False),
+        SharedFileMock(filename="test_1234M_test", isDirectory=False),
+    ]
+
+
 def test_get_all_shared_folder_contents(samba_mock: SMBConnectionMock):
     connection = pyndows.connect(
         "TestComputer", "127.0.0.1", 80, "TestDomain", "TestUser", "TestPassword"


### PR DESCRIPTION
### Added
- Mock now replaces the ? wildcard defined in [MS-CIFS protocol](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/dc92d939-ec45-40c8-96e5-4c4091e4ab43) by a point.
