### PR TITLE
Release 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.3.0] - 2020-02-04
 ### Fixed
 - retrieveFile mock was not working with Python < 3.8 in case retrieved file content was bytes.
 
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/pyndows/compare/v3.2.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pyndows/compare/v3.3.0...HEAD
+[3.3.0]: https://github.com/Colin-b/pyndows/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/Colin-b/pyndows/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/Colin-b/pyndows/releases/tag/v3.1.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Build status" src="https://api.travis-ci.org/Colin-b/pyndows.svg?branch=master"></a>
 <a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Number of tests" src="https://img.shields.io/badge/tests-25 passed-blue"></a>
+<a href="https://travis-ci.org/Colin-b/pyndows"><img alt="Number of tests" src="https://img.shields.io/badge/tests-38 passed-blue"></a>
 <a href="https://pypi.org/project/pyndows/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/pyndows"></a>
 </p>
 

--- a/pyndows/version.py
+++ b/pyndows/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "3.2.0"
+__version__ = "3.3.0"

--- a/tests/test_python36_37_compat.py
+++ b/tests/test_python36_37_compat.py
@@ -1,0 +1,11 @@
+import os
+
+from pyndows.testing import SMBConnectionMock
+
+
+def test_custom_is_file(monkeypatch):
+    def failing_is_file(*args):
+        raise ValueError
+
+    monkeypatch.setattr(os.path, "isfile", failing_is_file)
+    assert SMBConnectionMock._is_file(b"") is False


### PR DESCRIPTION
### Fixed
- Mock now replaces the `?` wildcard defined in [MS-CIFS protocol](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cifs/dc92d939-ec45-40c8-96e5-4c4091e4ab43) by a `.`.
