### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0] - 2020-07-28
+### Added
+- `write_to_new_folder_after` parameter to `pyndows.move` allowing to wait (or not), for a few seconds before writing file after a folder creation.
+
+### Changed
+- `pyndows.move` now waits 1 second in case of a folder creation before writing the file.
+
+### Fixed
+- Avoid warning in test cases on Windows when pytest could not remove the content of temporary folders.
+
 ## [4.0.0] - 2020-04-24
 ### Changed
 - Mock was entirely rewritten, check documentation for details.
@@ -44,7 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/pyndows/compare/v4.0.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pyndows/compare/v4.1.0...HEAD
+[4.1.0]: https://github.com/Colin-b/pyndows/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/Colin-b/pyndows/compare/v3.4.0...v4.0.0
 [3.4.0]: https://github.com/Colin-b/pyndows/compare/v3.3.1...v3.4.0
 [3.3.1]: https://github.com/Colin-b/pyndows/compare/v3.3.0...v3.3.1

--- a/pyndows/testing.py
+++ b/pyndows/testing.py
@@ -1,3 +1,4 @@
+import shutil
 from typing import List
 from collections import namedtuple
 import datetime
@@ -119,6 +120,12 @@ class SMBConnectionMock:
     def add_callback(cls, method_name: str, callback: callable):
         cls.monkeypatch.setattr(cls, method_name, callback)
 
+    @classmethod
+    def cleanup(cls):
+        mock_path = pathlib.Path(cls.tmpdir, "pyndows_samba_mock")
+        if mock_path.exists():
+            shutil.rmtree(mock_path)
+
 
 @pytest.fixture
 def samba_mock(monkeypatch, tmpdir) -> SMBConnectionMock:
@@ -133,6 +140,8 @@ def samba_mock(monkeypatch, tmpdir) -> SMBConnectionMock:
     monkeypatch.setattr(pyndows._windows, "SMBConnection", SMBConnectionMock)
 
     yield SMBConnectionMock
+
+    SMBConnectionMock.cleanup()
 
 
 _date_time_for_tests = datetime.datetime(2018, 10, 11, 15, 5, 5, 663979)

--- a/pyndows/version.py
+++ b/pyndows/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "4.0.0"
+__version__ = "4.1.0"


### PR DESCRIPTION
### Added
- `write_to_new_folder_after` parameter to `pyndows.move` allowing to wait (or not), for a few seconds before writing file after a folder creation.

### Changed
- `pyndows.move` now waits 1 second in case of a folder creation before writing the file.

### Fixed
- Avoid warning in test cases on Windows when pytest could not remove the content of temporary folders.
