### PR TITLE
Release 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.1] - 2020-08-04
+### Fixed
+- `SMBConnectionMock.listPath` now lists directories by default (as in `pysmb`).
+
 ## [4.2.0] - 2020-07-31
 ### Changed
 - Folder creation is now performed using a temporary folder name to avoid issues with folder not being available for file system listeners right away.
@@ -58,7 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/pyndows/compare/v4.2.0...HEAD
+[Unreleased]: https://github.com/Colin-b/pyndows/compare/v4.2.1...HEAD
+[4.2.1]: https://github.com/Colin-b/pyndows/compare/v4.2.0...v4.2.1
 [4.2.0]: https://github.com/Colin-b/pyndows/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/Colin-b/pyndows/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/Colin-b/pyndows/compare/v3.4.0...v4.0.0

--- a/pyndows/testing.py
+++ b/pyndows/testing.py
@@ -85,7 +85,11 @@ class SMBConnectionMock:
         )
 
     def listPath(
-        self, service_name: str, path: str, search: int = 0, pattern: str = "*"
+        self,
+        service_name: str,
+        path: str,
+        search: int = SMB_FILE_ATTRIBUTE_DIRECTORY,
+        pattern: str = "*",
     ) -> List[SharedFile]:
         files = [
             SharedFileMock(file.name, file.is_dir())

--- a/pyndows/version.py
+++ b/pyndows/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "4.2.0"
+__version__ = "4.2.1"


### PR DESCRIPTION
### Fixed
- `SMBConnectionMock.listPath` now lists directories by default (as in `pysmb`).
